### PR TITLE
Correct command line arguments and group/project filtering, add regex filename filtering, add unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ $
 
 ## Development
 ### Testing
-Use `gitlab-search-test.py` - replace `'TOKEN_CHANGE_ME!'` with same token used for main script and just call `python3 gitlab-search-test.py`
+Use [gitlab-search-test.py](gitlab-search-test.py) - replace `'TOKEN_CHANGE_ME!'` with same token used for main script and just call `python3 gitlab-search-test.py`
 
+This script uses this Gitlab group - [https://gitlab.com/test_group_for_gitlab-search_testing/](https://gitlab.com/test_group_for_gitlab-search_testing/)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo apt install python3-gitlab
 ### Usage
 
 ```
-usage: gitlab-search.py [-h] GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]
+usage: gitlab-search.py [-h] [--debug] GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]
 
 positional arguments:
   GITLAB_SERVER      URL of Gitlab server, eg. https://gitlab.com/
@@ -34,4 +34,5 @@ positional arguments:
 
 optional arguments:
   -h, --help         show this help message and exit
+  --debug            Show all API calls
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,19 @@ Alternatively, if you are working on Ubuntu or similar you can install required 
 sudo apt install python3-gitlab
 ```
 
-### Usage example:
+### Usage
 
-```bash
-python3 gitlab-search.py https://your-gitlab-server.com/ your_gitlab_user_token_key name_of_file_to_search_into text_to_search group project_filter
+```
+usage: gitlab-search.py [-h] GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]
+
+positional arguments:
+  GITLAB_SERVER      URL of Gitlab server, eg. https://gitlab.com/
+  GITLAB_USER_TOKEN  Access token with api_read access
+  FILE_FILTER        Filter for filenames to search in
+  TEXT_TO_SEARCH     Text to find in files
+  GROUP              Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup
+  PROJECT_FILTER     Filter for project names to look into
+
+optional arguments:
+  -h, --help         show this help message and exit
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # gitlab-search
 Python's script to search texts in any project
 
-### Requirements
+## Requirements
 The script has been executed successfully with Python 3.8.5
 
-### Installation
+## Installation
 In order to do work the script you can create a virtual environment:
 
 ```bash
@@ -19,7 +19,7 @@ Alternatively, if you are working on Ubuntu or similar you can install required 
 sudo apt install python3-gitlab
 ```
 
-### Usage
+## Usage
 
 ```
 usage: gitlab-search.py [-h] [--api-debug] [--internal-debug] [--filename-is-regex]
@@ -39,3 +39,21 @@ optional arguments:
   --internal-debug     Show all iterated items and other dubugv info
   --filename-is-regex  FILE_FILTER become Python regular expressions, so it can be '.*\.cpp' to search for all files with extension cpp
 ```
+
+### Example
+```
+$ python3 gitlab-search.py 'https://gitlab.com' $API_TOKEN '.*' 'foobar00' test_group_for_gitlab-search_testing --filename-is-regex --internal-debug    
+Number of projects that will be searched: 2
+Project:  test_project_2
+  File:  test.txt
+Project:  test_project_1
+  File:  README.md
+  File:  foobar_zero-zero-two
+[{'project': 'test_project_2', 'file': 'test.txt'}, {'project': 'test_project_1', 'file': 'README.md'}, {'project': 'test_project_1', 'file': 'foobar_zero-zero-two'}]
+$
+```
+
+## Development
+### Testing
+Use `gitlab-search-test.py` - replace `'TOKEN_CHANGE_ME!'` with same token used for main script and just call `python3 gitlab-search-test.py`
+

--- a/README.md
+++ b/README.md
@@ -22,17 +22,20 @@ sudo apt install python3-gitlab
 ### Usage
 
 ```
-usage: gitlab-search.py [-h] [--debug] GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]
+usage: gitlab-search.py [-h] [--api-debug] [--internal-debug] [--filename-is-regex]
+                        GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]
 
 positional arguments:
-  GITLAB_SERVER      URL of Gitlab server, eg. https://gitlab.com/
-  GITLAB_USER_TOKEN  Access token with api_read access
-  FILE_FILTER        Filter for filenames to search in
-  TEXT_TO_SEARCH     Text to find in files
-  GROUP              Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup
-  PROJECT_FILTER     Filter for project names to look into
+  GITLAB_SERVER        URL of Gitlab server, eg. https://gitlab.com/
+  GITLAB_USER_TOKEN    Access token with api_read access
+  FILE_FILTER          Filter for filenames to search in
+  TEXT_TO_SEARCH       Text to find in files
+  GROUP                Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup
+  PROJECT_FILTER       Filter for project names to look into
 
 optional arguments:
-  -h, --help         show this help message and exit
-  --debug            Show all API calls
+  -h, --help           show this help message and exit
+  --api-debug          Show all API calls
+  --internal-debug     Show all iterated items and other dubugv info
+  --filename-is-regex  FILE_FILTER become Python regular expressions, so it can be '.*\.cpp' to search for all files with extension cpp
 ```

--- a/gitlab-search-test.py
+++ b/gitlab-search-test.py
@@ -17,7 +17,7 @@ class TestGitlabSearch(unittest.TestCase):
         text_arg           = 'foobar00'
         project_filter_arg = None
 
-        self.assertEqual(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg), [{'project': 'test_project_2', 'file': 'test.txt'}, {'project': 'test_project_1', 'file': 'README.md'}, {'project': 'test_project_1', 'file': 'foobar_zero-zero-two'}])
+        self.assertEqual(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg), [{'file': 'README.md', 'project': 'test_project_3'}, {'project': 'test_project_2', 'file': 'test.txt'}, {'project': 'test_project_1', 'file': 'README.md'}, {'project': 'test_project_1', 'file': 'foobar_zero-zero-two'}])
 
     def test_02(self):
         regex_arg          = False

--- a/gitlab-search-test.py
+++ b/gitlab-search-test.py
@@ -1,0 +1,39 @@
+import unittest
+import importlib
+
+main_script=importlib.import_module('gitlab-search')
+search = getattr(main_script, 'search')
+
+api_debug_arg      = False
+internal_debug_arg = False
+gitlab_server_arg  = 'https://gitlab.com'
+token_arg          = 'TOKEN_CHANGE_ME!'
+group_arg          = 'test_group_for_gitlab-search_testing'
+
+class TestGitlabSearch(unittest.TestCase):
+    def test_01(self):
+        regex_arg          = True
+        file_filter_arg    = '.*'
+        text_arg           = 'foobar00'
+        project_filter_arg = None
+
+        self.assertEqual(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg), [{'project': 'test_project_2', 'file': 'test.txt'}, {'project': 'test_project_1', 'file': 'README.md'}, {'project': 'test_project_1', 'file': 'foobar_zero-zero-two'}])
+
+    def test_02(self):
+        regex_arg          = False
+        file_filter_arg    = '.*'
+        text_arg           = 'foobar00'
+        project_filter_arg = None
+
+        self.assertEqual(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg), [])
+
+    def test_03(self):
+        regex_arg          = False
+        file_filter_arg    = 'test.txt'
+        text_arg           = 'foobar00'
+        project_filter_arg = None
+
+        self.assertEqual(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg), [{'file': 'test.txt', 'project': 'test_project_2'}])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -25,9 +25,9 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
         projects = []
 
         if filter_projects:
-            group_projects = group_object.projects.list(search=project_filter)
+            group_projects = group_object.projects.list(search=project_filter, include_subgroups=True)
         else:
-            group_projects = group_object.projects.list(all=True)
+            group_projects = group_object.projects.list(all=True, include_subgroups=True)
             
         for group_project in group_projects:
             projects.append(gl.projects.get(group_project.id))

--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python3
 import gitlab
 import sys
+import argparse
 
 
 def search(gitlab_server, token, file_filter, text, group=None, project_filter=None):
     return_value = []
     gl = gitlab.Gitlab(gitlab_server, private_token=token)
-    if (project_filter == '') and (group == ''):
+    if (project_filter == '' or project_filter==None) and (group == '' or group==None):
         projects = gl.projects.list(all=True)
     else:
         group_object = gl.groups.get(group)
@@ -32,15 +33,20 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
     return return_value
 
 
-gitlab_server_arg = sys.argv[1]
-token_arg = sys.argv[2]
-file_filter_arg = sys.argv[3]
-text_arg = sys.argv[4]
-group_arg = sys.argv[5]
-project_filter_arg = sys.argv[6]
+parser = argparse.ArgumentParser()
+parser.add_argument("GITLAB_SERVER",     nargs=1,   help="URL of Gitlab server, eg. https://gitlab.com/")
+parser.add_argument("GITLAB_USER_TOKEN", nargs=1,   help="Access token with api_read access")
+parser.add_argument("FILE_FILTER",       nargs=1,   help="Filter for filenames to search in")
+parser.add_argument("TEXT_TO_SEARCH",    nargs=1,   help="Text to find in files")
+parser.add_argument("GROUP",             nargs='?', help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
+parser.add_argument("PROJECT_FILTER",    nargs='?', help="Filter for project names to look into")
+args = parser.parse_args()
 
-if len(sys.argv) < 4 or gitlab_server_arg == '' or token_arg == '' or file_filter_arg == '' or text_arg == '':
-    print('Missing mandatory fields. usage:')
-    print('./gitlab-search.py GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]')
-else:
-    print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg))
+gitlab_server_arg  = args.GITLAB_SERVER[0]
+token_arg          = args.GITLAB_USER_TOKEN[0]
+file_filter_arg    = args.FILE_FILTER[0]
+text_arg           = args.TEXT_TO_SEARCH[0]
+group_arg          = None if args.GROUP          == None else args.GROUP
+project_filter_arg = None if args.PROJECT_FILTER == None else args.PROJECT_FILTER
+
+print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg))

--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -32,16 +32,18 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
         for group_project in group_projects:
             projects.append(gl.projects.get(group_project.id))
 
-    eprint("Number of projects that will be searched:", len(projects))
     if internal_debug:
-        for p in projects:
-            if hasattr(p, 'path'):
-                path = p.path
-            else:
-                path = p.name
-            eprint("Project: ",path)
+        eprint("Number of projects that will be searched:", len(projects))
+
 
     for project in projects:
+        if internal_debug:
+            if hasattr(project, 'path'):
+                path = project.path
+            else:
+                path = project.name
+            eprint("Project: ",path)
+
         files = []
         try:
             files = project.repository_tree(recursive=True, all=True)
@@ -70,27 +72,27 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
     
     return return_value
 
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-debug",        action="store_true", help="Show all API calls")
+    parser.add_argument("--internal-debug",   action="store_true", help="Show all iterated items and other dubugv info")
+    parser.add_argument("--filename-is-regex",action="store_true", help="FILE_FILTER become Python regular expressions, so it can be '.*\.cpp' to search for all files with extension cpp")
+    parser.add_argument("GITLAB_SERVER",      nargs=1,             help="URL of Gitlab server, eg. https://gitlab.com/")
+    parser.add_argument("GITLAB_USER_TOKEN",  nargs=1,             help="Access token with api_read access")
+    parser.add_argument("FILE_FILTER",        nargs=1,             help="Filter for filenames to search in")
+    parser.add_argument("TEXT_TO_SEARCH",     nargs=1,             help="Text to find in files")
+    parser.add_argument("GROUP",              nargs='?',           help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
+    parser.add_argument("PROJECT_FILTER",     nargs='?',           help="Filter for project names to look into")
+    args = parser.parse_args()
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--api-debug",        action="store_true", help="Show all API calls")
-parser.add_argument("--internal-debug",   action="store_true", help="Show all iterated items and other dubugv info")
-parser.add_argument("--filename-is-regex",action="store_true", help="FILE_FILTER become Python regular expressions, so it can be '.*\.cpp' to search for all files with extension cpp")
-parser.add_argument("GITLAB_SERVER",      nargs=1,             help="URL of Gitlab server, eg. https://gitlab.com/")
-parser.add_argument("GITLAB_USER_TOKEN",  nargs=1,             help="Access token with api_read access")
-parser.add_argument("FILE_FILTER",        nargs=1,             help="Filter for filenames to search in")
-parser.add_argument("TEXT_TO_SEARCH",     nargs=1,             help="Text to find in files")
-parser.add_argument("GROUP",              nargs='?',           help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
-parser.add_argument("PROJECT_FILTER",     nargs='?',           help="Filter for project names to look into")
-args = parser.parse_args()
+    api_debug_arg      = args.api_debug
+    internal_debug_arg = args.internal_debug
+    regex_arg          = args.filename_is_regex
+    gitlab_server_arg  = args.GITLAB_SERVER[0]
+    token_arg          = args.GITLAB_USER_TOKEN[0]
+    file_filter_arg    = args.FILE_FILTER[0]
+    text_arg           = args.TEXT_TO_SEARCH[0]
+    group_arg          = None if args.GROUP          == None else args.GROUP
+    project_filter_arg = None if args.PROJECT_FILTER == None else args.PROJECT_FILTER
 
-api_debug_arg      = args.api_debug
-internal_debug_arg = args.internal_debug
-regex_arg          = args.filename_is_regex
-gitlab_server_arg  = args.GITLAB_SERVER[0]
-token_arg          = args.GITLAB_USER_TOKEN[0]
-file_filter_arg    = args.FILE_FILTER[0]
-text_arg           = args.TEXT_TO_SEARCH[0]
-group_arg          = None if args.GROUP          == None else args.GROUP
-project_filter_arg = None if args.PROJECT_FILTER == None else args.PROJECT_FILTER
-
-print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg))
+    print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg))

--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -4,9 +4,11 @@ import sys
 import argparse
 
 
-def search(gitlab_server, token, file_filter, text, group=None, project_filter=None):
+def search(gitlab_server, token, file_filter, text, group=None, project_filter=None, debug=False):
     return_value = []
     gl = gitlab.Gitlab(gitlab_server, private_token=token)
+    if debug:
+        gl.enable_debug()
     if (project_filter == '' or project_filter==None) and (group == '' or group==None):
         projects = gl.projects.list(all=True)
     else:
@@ -34,14 +36,16 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("GITLAB_SERVER",     nargs=1,   help="URL of Gitlab server, eg. https://gitlab.com/")
-parser.add_argument("GITLAB_USER_TOKEN", nargs=1,   help="Access token with api_read access")
-parser.add_argument("FILE_FILTER",       nargs=1,   help="Filter for filenames to search in")
-parser.add_argument("TEXT_TO_SEARCH",    nargs=1,   help="Text to find in files")
-parser.add_argument("GROUP",             nargs='?', help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
-parser.add_argument("PROJECT_FILTER",    nargs='?', help="Filter for project names to look into")
+parser.add_argument("--debug",           action="store_true", help="Show all API calls")
+parser.add_argument("GITLAB_SERVER",     nargs=1,             help="URL of Gitlab server, eg. https://gitlab.com/")
+parser.add_argument("GITLAB_USER_TOKEN", nargs=1,             help="Access token with api_read access")
+parser.add_argument("FILE_FILTER",       nargs=1,             help="Filter for filenames to search in")
+parser.add_argument("TEXT_TO_SEARCH",    nargs=1,             help="Text to find in files")
+parser.add_argument("GROUP",             nargs='?',           help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
+parser.add_argument("PROJECT_FILTER",    nargs='?',           help="Filter for project names to look into")
 args = parser.parse_args()
 
+debug_arg          = args.debug
 gitlab_server_arg  = args.GITLAB_SERVER[0]
 token_arg          = args.GITLAB_USER_TOKEN[0]
 file_filter_arg    = args.FILE_FILTER[0]
@@ -49,4 +53,4 @@ text_arg           = args.TEXT_TO_SEARCH[0]
 group_arg          = None if args.GROUP          == None else args.GROUP
 project_filter_arg = None if args.PROJECT_FILTER == None else args.PROJECT_FILTER
 
-print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg))
+print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, debug_arg))

--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -2,50 +2,90 @@
 import gitlab
 import sys
 import argparse
+import re
 
+def eprint(*args, **kwargs):
+    # https://stackoverflow.com/a/14981125
+    print(*args, file=sys.stderr, **kwargs)
 
-def search(gitlab_server, token, file_filter, text, group=None, project_filter=None, debug=False):
+def search(gitlab_server, token, file_filter, text, group=None, project_filter=None, api_debug=False, internal_debug=False, filename_regex=False):
     return_value = []
+    
     gl = gitlab.Gitlab(gitlab_server, private_token=token)
-    if debug:
+    if api_debug:
         gl.enable_debug()
-    if (project_filter == '' or project_filter==None) and (group == '' or group==None):
+
+    filter_groups   = not (group == '' or group==None)
+    filter_projects = not (project_filter == '' or project_filter==None)
+
+    if not filter_groups and not filter_projects:
         projects = gl.projects.list(all=True)
     else:
         group_object = gl.groups.get(group)
-        group_projects = group_object.projects.list(search=project_filter)
         projects = []
+
+        if filter_projects:
+            group_projects = group_object.projects.list(search=project_filter)
+        else:
+            group_projects = group_object.projects.list(all=True)
+            
         for group_project in group_projects:
             projects.append(gl.projects.get(group_project.id))
-    print("Number of projects:", len(projects))
+
+    eprint("Number of projects that will be searched:", len(projects))
+    if internal_debug:
+        for p in projects:
+            if hasattr(p, 'path'):
+                path = p.path
+            else:
+                path = p.name
+            eprint("Project: ",path)
+
     for project in projects:
         files = []
         try:
             files = project.repository_tree(recursive=True, all=True)
         except Exception as e:
             print(str(e), "Error getting tree in project:", project.name)
+
         for file in files:
-            if file_filter == file['name']:
+            if internal_debug:
+                fpath = file.get('path',None) if file.get('path',None)!=None else file.get('name',None)
+                eprint("  File: ",fpath)
+
+            if filename_regex:
+                matches=re.findall(file_filter, file['name'])
+                filename_matches = len(matches)>0
+            else:
+                filename_matches=file_filter == file['name']
+            
+            if filename_matches:
                 file_content = project.files.raw(file_path=file['path'], ref='master')
+                
                 if text in str(file_content):
                     return_value.append({
                         "project": project.name,
                         "file": file['path']
                     })
+    
     return return_value
 
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--debug",           action="store_true", help="Show all API calls")
-parser.add_argument("GITLAB_SERVER",     nargs=1,             help="URL of Gitlab server, eg. https://gitlab.com/")
-parser.add_argument("GITLAB_USER_TOKEN", nargs=1,             help="Access token with api_read access")
-parser.add_argument("FILE_FILTER",       nargs=1,             help="Filter for filenames to search in")
-parser.add_argument("TEXT_TO_SEARCH",    nargs=1,             help="Text to find in files")
-parser.add_argument("GROUP",             nargs='?',           help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
-parser.add_argument("PROJECT_FILTER",    nargs='?',           help="Filter for project names to look into")
+parser.add_argument("--api-debug",        action="store_true", help="Show all API calls")
+parser.add_argument("--internal-debug",   action="store_true", help="Show all iterated items and other dubugv info")
+parser.add_argument("--filename-is-regex",action="store_true", help="FILE_FILTER become Python regular expressions, so it can be '.*\.cpp' to search for all files with extension cpp")
+parser.add_argument("GITLAB_SERVER",      nargs=1,             help="URL of Gitlab server, eg. https://gitlab.com/")
+parser.add_argument("GITLAB_USER_TOKEN",  nargs=1,             help="Access token with api_read access")
+parser.add_argument("FILE_FILTER",        nargs=1,             help="Filter for filenames to search in")
+parser.add_argument("TEXT_TO_SEARCH",     nargs=1,             help="Text to find in files")
+parser.add_argument("GROUP",              nargs='?',           help="Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup")
+parser.add_argument("PROJECT_FILTER",     nargs='?',           help="Filter for project names to look into")
 args = parser.parse_args()
 
-debug_arg          = args.debug
+api_debug_arg      = args.api_debug
+internal_debug_arg = args.internal_debug
+regex_arg          = args.filename_is_regex
 gitlab_server_arg  = args.GITLAB_SERVER[0]
 token_arg          = args.GITLAB_USER_TOKEN[0]
 file_filter_arg    = args.FILE_FILTER[0]
@@ -53,4 +93,4 @@ text_arg           = args.TEXT_TO_SEARCH[0]
 group_arg          = None if args.GROUP          == None else args.GROUP
 project_filter_arg = None if args.PROJECT_FILTER == None else args.PROJECT_FILTER
 
-print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, debug_arg))
+print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-gitlab
+argparse


### PR DESCRIPTION
I've used `argparse` to make handling of command line arguments nicer and less prone to errors and add auto-generated ``--help` view.
Besides optional regex filtering I've added unit testing based on simple project group on GitLab - (https://gitlab.com/test_group_for_gitlab-search_testing/) to demo that script works as expected and prove future changes won't break expected behaviour. 