### PR TITLE
fix: remove directories to be analyzed

### DIFF
--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -50,6 +50,11 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
         except Exception as e:
             print(str(e), "Error getting tree in project:", project.name)
 
+        # remove files to be analyzed from the list that are directories
+        for file in files[:]:
+            if file['type'] == 'tree':
+                files.remove(file)
+
         for file in files:
             if internal_debug:
                 fpath = file.get('path',None) if file.get('path',None)!=None else file.get('name',None)


### PR DESCRIPTION
Files that are actually directories in the repository are kept in `files[]` to be analyzed regarding the `TEXT_TO_SEARCH`.

But we cannot read a directory as a raw, so it produces the following error when it tries to read the directory content as a raw : 

```
$ ./gitlab-search.py --api-debug --filename-is-regex $GITLAB_URL $GITLAB_TOKEN '.*' 'text_to_find'

reply: 'HTTP/1.1 404 Not Found\r\n'
header: Server: nginx
header: Date: Thu, 17 Jun 2021 13:56:45 GMT
header: Content-Type: application/json
header: Content-Length: 32
header: Cache-Control: no-cache
header: Vary: Origin
header: X-Content-Type-Options: nosniff
header: X-Frame-Options: SAMEORIGIN
header: X-Gitlab-Feature-Category: source_code_management
header: X-Request-Id: 01F8D451D7Y5ZRCNJ8BBMR9GMN
header: X-Runtime: 0.026860
Traceback (most recent call last):
  File "/home/xat/.local/lib/python3.9/site-packages/gitlab/exceptions.py", line 304, in wrapped_f
    return f(*args, **kwargs)
  File "/home/xat/.local/lib/python3.9/site-packages/gitlab/v4/objects/files.py", line 203, in raw
    result = self.gitlab.http_get(
  File "/home/xat/.local/lib/python3.9/site-packages/gitlab/client.py", line 629, in http_get
    result = self.http_request(
  File "/home/xat/.local/lib/python3.9/site-packages/gitlab/client.py", line 595, in http_request
    raise gitlab.exceptions.GitlabHttpError(
gitlab.exceptions.GitlabHttpError: 404: 404 File Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/xat/gitlab-search.py", line 108, in <module>
    print(search(gitlab_server_arg, token_arg, file_filter_arg, text_arg, group_arg, project_filter_arg, api_debug_arg, internal_debug_arg, regex_arg))
  File "/home/xat/gitlab-search.py", line 75, in search
    file_content = project.files.raw(file_path=file['path'], ref='master')
  File "/home/xat/.local/lib/python3.9/site-packages/gitlab/cli.py", line 60, in wrapped_f
    return f(*args, **kwargs)
  File "/home/xat/.local/lib/python3.9/site-packages/gitlab/exceptions.py", line 306, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body) from e
gitlab.exceptions.GitlabGetError: 404: 404 File Not Found

```

So after creating the files list, I just check if the file is not a file of type `tree` that means it is a directory in the repo. If the current file is a `tree` type, I remove it from the list.