### PR TITLE
Possiblity to filter on git branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # gitlab-search
+
 Python's script to search texts in any project
 
 ## Requirements
-The script has been executed successfully with Python 3.8.5
+
+The script has been executed successfully with Python 3.8.x, and 3.9.x .
 
 ## Installation
+
 In order to do work the script you can create a virtual environment:
 
 ```bash
@@ -23,7 +26,7 @@ sudo apt install python3-gitlab
 
 ```
 usage: gitlab-search.py [-h] [--api-debug] [--internal-debug] [--filename-is-regex]
-                        GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER]
+                        GITLAB_SERVER GITLAB_USER_TOKEN FILE_FILTER TEXT_TO_SEARCH [GROUP] [PROJECT_FILTER] [BRANCH_FILTER]
 
 positional arguments:
   GITLAB_SERVER        URL of Gitlab server, eg. https://gitlab.com/
@@ -32,6 +35,7 @@ positional arguments:
   TEXT_TO_SEARCH       Text to find in files
   GROUP                Group to search for projects in, can be subgroup eg. parent_group/subgroup/another_subgroup
   PROJECT_FILTER       Filter for project names to look into
+  BRANCH_FILTER        Filter for branch names to look into, separated by commas. Eg. 'master,dev,v1.0'
 
 optional arguments:
   -h, --help           show this help message and exit
@@ -45,16 +49,21 @@ optional arguments:
 $ python3 gitlab-search.py 'https://gitlab.com' $API_TOKEN '.*' 'foobar00' test_group_for_gitlab-search_testing --filename-is-regex --internal-debug    
 Number of projects that will be searched: 2
 Project:  test_project_2
-  File:  test.txt
+  Branch: master
+    File:  test.txt
 Project:  test_project_1
-  File:  README.md
-  File:  foobar_zero-zero-two
-[{'project': 'test_project_2', 'file': 'test.txt'}, {'project': 'test_project_1', 'file': 'README.md'}, {'project': 'test_project_1', 'file': 'foobar_zero-zero-two'}]
-$
+  Branch: master
+    File:  README.md
+  Branch: dev
+    File:  README.md
+    File:  foobar_zero-zero-two
+[{'project': 'test_project_2', 'branch':'master', 'file': 'test.txt'}, {'project': 'test_project_1', 'branch': 'master', 'file': 'README.md'}, {'project': 'test_project_1', 'branch': 'dev', 'file': 'README.md'}, {'project': 'test_project_1', 'branch':'dev', 'file': 'foobar_zero-zero-two'}]
 ```
 
 ## Development
+
 ### Testing
+
 Use [gitlab-search-test.py](gitlab-search-test.py) - replace `'TOKEN_CHANGE_ME!'` with same token used for main script and just call `python3 gitlab-search-test.py`
 
 This script uses this Gitlab group - [https://gitlab.com/test_group_for_gitlab-search_testing/](https://gitlab.com/test_group_for_gitlab-search_testing/)

--- a/gitlab-search.py
+++ b/gitlab-search.py
@@ -50,6 +50,11 @@ def search(gitlab_server, token, file_filter, text, group=None, project_filter=N
         except Exception as e:
             print(str(e), "Error getting tree in project:", project.name)
 
+        # remove files to be analyzed from the list that are directories
+        for file in files[:]:
+            if file['type'] == 'tree':
+                files.remove(file)
+
         for file in files:
             if internal_debug:
                 fpath = file.get('path',None) if file.get('path',None)!=None else file.get('name',None)


### PR DESCRIPTION
We can now filter on git branches to search into using the `BRANCH_FILTER` argument.

If not set, the script parse all the branches of the specified git projects.